### PR TITLE
[Fix] Eliminar espacios finales en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Este proyecto demuestra el uso de Gradio para:
 
 ## Cómo ejecutar
 
-pip install gradio  
+pip install gradio
 python qwen3_demo.py
 
 ## Pruebas


### PR DESCRIPTION
## Resumen
Se eliminaron los espacios en blanco al final de la línea que contiene `pip install gradio` y se revisó el archivo para asegurar que no queden espacios sobrantes.

## Pruebas realizadas
- `flake8` *(falló: comando no encontrado)*
- `pytest -q` *(falló por falta del módulo `gradio`)*

------
https://chatgpt.com/codex/tasks/task_e_68685392e5cc8331b65998b0072252d0